### PR TITLE
chore: add retry on keybase get validator image

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "react-scripts": "3.4.0",
     "redux": "^4.0.5",
     "redux-devtools-extension": "^2.13.8",
-    "redux-thunk": "^2.3.0"
+    "redux-thunk": "^2.3.0",
+    "retry-axios": "^2.6.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/actions/stake.js
+++ b/src/actions/stake.js
@@ -26,6 +26,7 @@ import {
     VALIDATORS_FETCH_SUCCESS,
 } from '../constants/stake';
 import Axios from 'axios';
+import * as rax from 'retry-axios';
 import { getDelegatedValidatorsURL, getValidatorURL, validatorImageURL, VALIDATORS_LIST_URL } from '../constants/url';
 
 const fetchValidatorsInProgress = () => {
@@ -269,6 +270,10 @@ const fetchValidatorImageError = (message) => {
 export const fetchValidatorImage = (id) => (dispatch) => {
     dispatch(fetchValidatorImageInProgress());
     const URL = validatorImageURL(id);
+
+	// setup axios-retry
+	rax.attach();
+
     Axios.get(URL, {
         headers: {
             Accept: 'application/json, text/plain, */*',

--- a/yarn.lock
+++ b/yarn.lock
@@ -11071,6 +11071,11 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
+retry-axios@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/retry-axios/-/retry-axios-2.6.0.tgz#d4dc5c8a8e73982e26a705e46a33df99a28723e0"
+  integrity sha512-pOLi+Gdll3JekwuFjXO3fTq+L9lzMQGcSq7M5gIjExcl3Gu1hd4XXuf5o3+LuSBsaULQH7DiNbsqPd1chVpQGQ==
+
 retry@^0.10.0, retry@~0.10.0:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"


### PR DESCRIPTION
Hello,

I noticed there was an error when I wanted to see my validator image.

i found out the problem was because of keybase 429 Too many request...

this PR simply add a retry on the request, I think it's an efficient quickfix, but a better slow-loading of the page should be implemented.